### PR TITLE
add `dku::serialization` feature

### DIFF
--- a/include/DKUtil/Extra.hpp
+++ b/include/DKUtil/Extra.hpp
@@ -12,16 +12,26 @@
 
 
 #include "Impl/pch.hpp"
-#include "Logger.hpp"
-#include "Utility.hpp"
+
+#include "Impl/Extra/xconsole.hpp"
+#include "Impl/Extra/xserialize.hpp"
 
 
-#define CONSOLE(...)                                          \
-	{                                                         \
-		if (auto* console = RE::ConsoleLog::GetSingleton()) { \
-			auto fmt = fmt::format(__VA_ARGS__);              \
-			INFO("[console] {}", fmt);                        \
-			fmt = PROJECT_NAME + " -> "s + fmt;               \
-			console->Print(fmt.c_str());                      \
-		}                                                     \
-	}
+#define DKU_X_VERSION_MAJOR 1
+#define DKU_X_VERSION_MINOR 0
+#define DKU_X_VERSION_REVISION 0
+
+
+namespace DKUtil
+{
+	constexpr auto DKU_X_VERSION = DKU_X_VERSION_MAJOR * 10000 + DKU_X_VERSION_MINOR * 100 + DKU_X_VERSION_REVISION;
+}  // namespace DKUtil
+
+
+namespace DKUtil
+{
+	template <typename T, dku::string::static_string H>
+	using serializable = DKUtil::serialization::Serializable<T, H>;
+
+	using ResolveType = DKUtil::serialization::ResolveOrder;
+} // DKUtil

--- a/include/DKUtil/Impl/Config/Data.hpp
+++ b/include/DKUtil/Impl/Config/Data.hpp
@@ -6,18 +6,6 @@
 
 namespace DKUtil::Config::detail
 {
-	template <typename data_t>
-	concept dku_c_numeric =
-		(std::convertible_to<data_t, std::int64_t> || std::convertible_to<data_t, double>) && !
-	std::convertible_to<data_t, std::basic_string<char>>;
-
-
-	template <typename data_t>
-	concept dku_c_trivial_t =
-		(dku_c_numeric<data_t> || std::convertible_to<data_t, bool>) && !
-	std::convertible_to<data_t, std::basic_string<char>>;
-
-
 	enum class DataType
 	{
 		kBoolean,
@@ -174,14 +162,14 @@ namespace DKUtil::Config::detail
 
 		constexpr void set_range(std::pair<double, double> a_range)
 		{
-			if constexpr (dku_c_numeric<data_t>) {
+			if constexpr (model::concepts::dku_numeric<data_t>) {
 				_range = a_range;
 			}
 		}
 
 		constexpr void clamp()
 		{
-			if (!dku_c_numeric<data_t> || _range.first > _range.second) {
+			if (!model::concepts::dku_numeric<data_t> || _range.first > _range.second) {
 				return;
 			}
 

--- a/include/DKUtil/Impl/Config/Ini.hpp
+++ b/include/DKUtil/Impl/Config/Ini.hpp
@@ -86,20 +86,20 @@ namespace DKUtil::Config::detail
 						case DataType::kString:
 							{
 								std::string old{ raw };
-								dku::string::replace_nth_instance(raw, 0, "\\,", "_dku_comma_");
-								dku::string::replace_nth_instance(raw, 0, "\\\"", "_dku_quote_");
+								dku::string::replace_nth_occurrence(raw, 0, "\\,", "_dku_comma_");
+								dku::string::replace_nth_occurrence(raw, 0, "\\\"", "_dku_quote_");
 
 								auto sv = dku::string::split(raw, ",");
 								try {
 									if (sv.size() <= 1) {
 										dku::string::trim(old);
-										dku::string::replace_nth_instance(old, 0, "\"");
+										dku::string::replace_nth_occurrence(old, 0, "\"");
 										data->As<std::basic_string<char>>()->set_data(old);
 									} else {
 										std::ranges::for_each(sv, [](std::string& str) {
-											dku::string::replace_nth_instance(str, 0, "\"");
-											dku::string::replace_nth_instance(str, 0, "_dku_comma_", "\\,");
-											dku::string::replace_nth_instance(str, 0, "_dku_quote_", "\\\"");
+											dku::string::replace_nth_occurrence(str, 0, "\"");
+											dku::string::replace_nth_occurrence(str, 0, "_dku_comma_", "\\,");
+											dku::string::replace_nth_occurrence(str, 0, "_dku_quote_", "\\\"");
 											dku::string::trim(str);
 										});
 										data->As<std::basic_string<char>>()->set_data(sv);

--- a/include/DKUtil/Impl/Extra/Serialization/exception.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/exception.hpp
@@ -8,32 +8,35 @@ namespace DKUtil::serialization
 {
 	namespace exception
 	{
-		enum class code : std::uint32_t
+		enum class code : index_type
 		{
 			failed_to_open_record,
-			failed_to_write_size,
 			failed_to_write_data,
-
-			failed_to_read_size,
 			failed_to_read_data,
 			failed_to_resolve_formId,
-
 			failed_to_revert,
 
-			unsupported_type_queue,
 			unexpected_type_mismatch,
 			bindable_type_unpackable,
 			internal_buffer_overflow,
+			invalid_skse_interface,
 		};
 
-		template <typename T, typename... Fmt>
+#define DKU_XS_EXCEPTION_FMT                                                    \
+	"Serialization error\n[{}]\n\nrecord: {}\nversion: {}\ntype: {}\n\n{}\n\n", \
+		dku::print_enum(a_code), a_header.name, a_header.version, typeid(T).name(), a_fmt
+
+		template <typename T, bool PROMPT = DKU_X_STRICT_SERIALIZATION>
 		void report(
 			code a_code, 
-			ISerializable::Header a_header = { "DKU_X: <intenral resolver>", 0x1234, DKU_XS_VERSION }, 
-			std::string_view a_fmt = {})
+			std::string_view a_fmt = {},
+			ISerializable::Header a_header = { "DKU_X: <intenral resolver>", 0x1234, DKU_XS_VERSION })
 		{
-			ERROR("Serialization error\n[{}]\n\nrecord: {}\nversion: {}\ntype: {}\n\n{}\n\n",
-				dku::print_enum(a_code), a_header.name, a_header.version, typeid(T).name(), a_fmt);
+			if constexpr (PROMPT) {
+				ERROR(DKU_XS_EXCEPTION_FMT);
+			} else {
+				WARN(DKU_XS_EXCEPTION_FMT);
+			}
 		}
 	}  // namespace exception
 } // namespace DKUtil::serialization

--- a/include/DKUtil/Impl/Extra/Serialization/exception.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/exception.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+
+#include "shared.hpp"
+
+
+namespace DKUtil::serialization
+{
+	namespace exception
+	{
+		enum class code : std::uint32_t
+		{
+			failed_to_open_record,
+			failed_to_write_size,
+			failed_to_write_data,
+
+			failed_to_read_size,
+			failed_to_read_data,
+			failed_to_resolve_formId,
+
+			failed_to_revert,
+
+			unsupported_type_queue,
+			unexpected_type_mismatch,
+			bindable_type_unpackable,
+			internal_buffer_overflow,
+		};
+
+		template <typename T, typename... Fmt>
+		void report(
+			code a_code, 
+			ISerializable::Header a_header = { "DKU_X: <intenral resolver>", 0x1234, DKU_XS_VERSION }, 
+			std::string_view a_fmt = {})
+		{
+			ERROR("Serialization error\n[{}]\n\nrecord: {}\nversion: {}\ntype: {}\n\n{}\n\n",
+				dku::print_enum(a_code), a_header.name, a_header.version, typeid(T).name(), a_fmt);
+		}
+	}  // namespace exception
+} // namespace DKUtil::serialization

--- a/include/DKUtil/Impl/Extra/Serialization/interface.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/interface.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+
+#include "shared.hpp"
+#include "exception.hpp"
+
+
+namespace DKUtil::serialization
+{
+	namespace api
+	{
+		namespace detail
+		{
+			inline auto* check_skse_intfc(SKSE::SerializationInterface* a_intfc = nullptr)
+			{
+				const auto* intfc = a_intfc ? a_intfc : SKSE::GetSerializationInterface();
+
+				if (!a_intfc && !intfc) {
+					exception::report<decltype(intfc)>(exception::code::invalid_skse_interface);
+				}
+
+				return intfc;
+			}
+
+
+			void save_all(SKSE::SerializationInterface* a_intfc)
+			{
+#ifndef DKU_X_MOCK
+				check_skse_intfc(a_intfc);
+
+				for (auto* serializable : ISerializable::ManagedSerializables) {
+					if (!a_intfc->OpenRecord(serializable->header.hash, serializable->header.version)) {
+						exception::report<decltype(serializable)>(exception::code::failed_to_open_record, 
+							fmt::format("type: {}", serializable->typeInfo));
+						continue;
+					} else {
+						serializable->try_save();
+					}
+				}
+#endif
+			}
+
+
+			void load_all(SKSE::SerializationInterface* a_intfc)
+			{
+#ifndef DKU_X_MOCK
+				check_skse_intfc(a_intfc);
+
+				std::uint32_t hash, version, length;
+				while (a_intfc->GetNextRecordInfo(hash, version, length)) {
+					for (auto* serializable : ISerializable::ManagedSerializables) {
+						serializable->try_load(hash, version);
+					}
+				}
+#endif
+			}
+
+
+			void revert_all(SKSE::SerializationInterface* a_intfc)
+			{
+				for (auto* serializable : ISerializable::ManagedSerializables) {
+					serializable->try_revert();
+				}
+			}
+		}  // namespace detail
+
+
+#ifndef DKU_X_MOCK
+
+
+#	define DKU_X_WRITE(D, L, T) api::write<T>(D, L, a_res.header)
+#	define DKU_X_WRITE_SIZE(D) DKU_X_WRITE(std::addressof(D), sizeof(D), decltype(data))
+#	define DKU_X_READ(D, L, T) api::read(D, L, a_res.header)
+#	define DKU_X_READ_SIZE(D) DKU_X_READ(std::addressof(D), sizeof(D), decltype(data))
+#	define DKU_X_REPORT() api::report()
+#	define DKU_X_FORMID(F) api::resolveFormId(F)
+
+
+		template <typename T = void>
+		inline void write(const void* a_buf, size_type a_length, const ISerializable::Header& a_header) noexcept
+		{
+			const auto* intfc = detail::check_skse_intfc();
+			if (!intfc->WriteRecordData(a_buf, a_length)) {
+				exception::report<T>(exception::code::failed_to_write_data, 
+					fmt::format("size: {}B", a_length), a_header);
+			}
+		}
+
+		template <typename T = void>
+		inline void read(void* a_buf, size_type a_length, const ISerializable::Header& a_header) noexcept
+		{
+			const auto* intfc = detail::check_skse_intfc();
+			if (!intfc->ReadRecordData(a_buf, a_length)) {
+				exception::report<T>(exception::code::failed_to_read_data,
+					fmt::format("size: {}B", a_length), a_header);
+			}
+		}
+
+		inline RE::FormID resolveFormId(RE::FormID a_form) noexcept
+		{
+			RE::FormID newForm;
+			const auto* intfc = detail::check_skse_intfc();
+
+			if (!intfc->ResolveFormID(a_form, newForm) && !newForm) {
+				exception::report<RE::FormID>(exception::code::failed_to_resolve_formId,
+					fmt::format("old formId: {:X} | resolved: {:X}", a_form, newForm));
+			}
+
+			return newForm;
+		}
+
+		inline void report() noexcept
+		{
+			const auto* intfc = detail::check_skse_intfc();
+			DEBUG("\nSKSE::SerializationInterface version: {}\nDKU_X_SERIALIZE version: {}", intfc->Version(), DKU_XS_VERSION);
+		}
+#endif
+
+
+		inline void RegisterSerializable(std::string a_ref = {}) noexcept
+		{
+			const auto* intfc = detail::check_skse_intfc();
+
+			a_ref += "_DKU_XS";
+			auto&& [key, hash] = colliding::make_hash_key(a_ref.data());
+
+			intfc->SetUniqueID(hash);
+			intfc->SetSaveCallback(detail::save_all);
+			intfc->SetLoadCallback(detail::load_all);
+			intfc->SetRevertCallback(detail::revert_all);
+
+			DEBUG("DKU_XS: Registered serializables\nplugin handle {}\nplugin hash {}", key, hash);
+			DKU_X_REPORT();
+		}
+	}  // DKUtil::serialization::api
+}  // DKUtil::serialization

--- a/include/DKUtil/Impl/Extra/Serialization/mock.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/mock.hpp
@@ -6,12 +6,15 @@
 
 
 #ifdef DKU_X_MOCK
-#	include "mock.hpp"
 #	include <fmt/color.h>
 
-#	define DKU_X_MOCK_WRITE(D, L) mock::write(D, L)
-#	define DKU_X_MOCK_READ(D, L) mock::read(D, L)
-#	define DKU_X_MOCK_REPORT() mock::report()
+
+#	define DKU_X_WRITE(D, L, T) mock::write(D, L)
+#	define DKU_X_WRITE_SIZE(D) DKU_X_WRITE(std::addressof(D), sizeof(D), decltype(D))
+#	define DKU_X_READ(D, L, T) mock::read(D, L)
+#	define DKU_X_READ_SIZE(D) DKU_X_READ(std::addressof(D), sizeof(D), decltype(D))
+#	define DKU_X_REPORT() mock::report()
+#	define DKU_X_FORMID(F) F
 
 
 namespace DKUtil::serialization
@@ -19,11 +22,11 @@ namespace DKUtil::serialization
 	namespace mock
 	{
 		inline static std::array<std::byte, 0x1000> Buffer;
-		inline static std::size_t ReadPos = 0;
-		inline static std::size_t WritePos = 0;
+		inline static size_type ReadPos = 0;
+		inline static size_type WritePos = 0;
 
 
-		void read(void* a_buf, std::uint32_t a_length) noexcept
+		inline void read(void* a_buf, size_type a_length) noexcept
 		{
 			std::memcpy(a_buf, Buffer.data() + ReadPos, a_length);
 			ReadPos += a_length;
@@ -32,7 +35,7 @@ namespace DKUtil::serialization
 				"[mock] read {}B", a_length));
 		}
 
-		void write(const void* a_buf, std::uint32_t a_length) noexcept
+		inline void write(const void* a_buf, size_type a_length) noexcept
 		{
 			std::memcpy(Buffer.data() + WritePos, a_buf, a_length);
 			WritePos += a_length;
@@ -41,24 +44,18 @@ namespace DKUtil::serialization
 				"[mock] write {}B", a_length));
 		}
 
-		void clear() noexcept
+		inline void clear() noexcept
 		{
 			Buffer.fill(std::byte{ 0 });
 			ReadPos = 0;
 			WritePos = 0;
 		}
 
-		void report() noexcept
+		inline void report() noexcept
 		{
 			INFO("[mock] current read {}B", ReadPos);
 			INFO("[mock] current write {}B", WritePos);
 		}
 	}  // namespace mock
 } // namespace DKUtil::serialization
-
-#else
-#	define DKU_X_MOCK_WRITE(a_res, a_data)
-#	define DKU_X_MOCK_READ(a_res, a_data)
-#	define DKU_X_MOCK_READ_WRITE(a_res, a_data)
-#	define DKU_X_MOCK_REPORT()
 #endif

--- a/include/DKUtil/Impl/Extra/Serialization/mock.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/mock.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+
+#include "shared.hpp"
+#include "exception.hpp"
+
+
+#ifdef DKU_X_MOCK
+#	include "mock.hpp"
+#	include <fmt/color.h>
+
+#	define DKU_X_MOCK_WRITE(D, L) mock::write(D, L)
+#	define DKU_X_MOCK_READ(D, L) mock::read(D, L)
+#	define DKU_X_MOCK_REPORT() mock::report()
+
+
+namespace DKUtil::serialization
+{
+	namespace mock
+	{
+		inline static std::array<std::byte, 0x1000> Buffer;
+		inline static std::size_t ReadPos = 0;
+		inline static std::size_t WritePos = 0;
+
+
+		void read(void* a_buf, std::uint32_t a_length) noexcept
+		{
+			std::memcpy(a_buf, Buffer.data() + ReadPos, a_length);
+			ReadPos += a_length;
+			INFO(fmt::format(
+				fmt::bg(fmt::terminal_color::green) | fmt::fg(fmt::terminal_color::black), 
+				"[mock] read {}B", a_length));
+		}
+
+		void write(const void* a_buf, std::uint32_t a_length) noexcept
+		{
+			std::memcpy(Buffer.data() + WritePos, a_buf, a_length);
+			WritePos += a_length;
+			INFO(fmt::format(
+				fmt::bg(fmt::terminal_color::cyan) | fmt::fg(fmt::terminal_color::black), 
+				"[mock] write {}B", a_length));
+		}
+
+		void clear() noexcept
+		{
+			Buffer.fill(std::byte{ 0 });
+			ReadPos = 0;
+			WritePos = 0;
+		}
+
+		void report() noexcept
+		{
+			INFO("[mock] current read {}B", ReadPos);
+			INFO("[mock] current write {}B", WritePos);
+		}
+	}  // namespace mock
+} // namespace DKUtil::serialization
+
+#else
+#	define DKU_X_MOCK_WRITE(a_res, a_data)
+#	define DKU_X_MOCK_READ(a_res, a_data)
+#	define DKU_X_MOCK_READ_WRITE(a_res, a_data)
+#	define DKU_X_MOCK_REPORT()
+#endif

--- a/include/DKUtil/Impl/Extra/Serialization/resolver.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/resolver.hpp
@@ -1,0 +1,287 @@
+#pragma once
+
+
+#include "shared.hpp"
+#include "exception.hpp"
+#include "mock.hpp"
+
+
+namespace DKUtil::serialization
+{
+	namespace resolver
+	{
+		namespace detail
+		{
+#ifdef DKU_X_MOCK
+#	define DKU_X_ENTER_LAYOUT(t) INFO("\t{:->{}}"##t, "", ++detail::ResolvedLayoutMap[a_res.header.name])
+#	define DKU_X_LEAVE_LAYOUT() --detail::ResolvedLayoutMap[a_res.header.name]
+#else
+#	define DKU_X_ENTER_LAYOUT(t)
+#	define DKU_X_LEAVE_LAYOUT()
+#endif
+
+#ifndef DKU_X_BUFFER_SIZE
+#	define DKU_X_BUFFER_SIZE 0x200
+#endif
+
+			struct Buffer
+			{
+				template <typename T = void*>
+				constexpr auto alloc(size_type a_size) noexcept
+				{
+					if (pos + a_size > data.size()) {
+						exception::report<decltype(data)>(exception::code::internal_buffer_overflow);
+					}
+
+					auto* rv = static_cast<T>(data.data() + pos);
+					pos += a_size;
+
+					return rv;
+				}
+
+				constexpr auto clear() noexcept
+				{
+					pos = 0;
+					data.fill(std::byte{ 0 });
+				}
+
+				size_type pos = 0;
+				std::array<std::byte, DKU_X_BUFFER_SIZE> data = {};
+			};
+
+
+			inline static std::unordered_map<key_type, std::uint32_t> ResolvedLayoutMap = {};
+		} // namespace detail
+
+		
+		struct ResolveInfo
+		{
+			ResolveOrder order;
+			ISerializable::Header header;
+			SKSE::SerializationInterface* intfc;
+		};
+
+
+		using namespace model::concepts;
+
+		template <typename T>
+			requires(dku_trivial<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T>
+			requires(dku_ranges<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T>
+			requires(dku_aggregate<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T>
+			requires(dku_bindable<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T, std::size_t N>
+			requires(dku_bindable<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T>
+			requires(dku_string<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T>
+			requires(std::is_void_v<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+		template <typename T>
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept;
+
+
+		// trivial types, int, float, bool
+		template <typename T>
+			requires(dku_trivial<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			DKU_X_ENTER_LAYOUT("trivial");
+
+			T data = a_data;
+
+			if (a_res.order == ResolveOrder::kSave) {
+				DKU_X_MOCK_WRITE(&data, sizeof(data));
+			} else {
+				DKU_X_MOCK_READ(&data, sizeof(data));
+			}
+
+			DKU_X_LEAVE_LAYOUT();
+
+			return data;
+		}
+
+		// ranges containers
+		template <typename T>
+			requires(dku_ranges<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			DKU_X_ENTER_LAYOUT("container");
+
+			auto data = model::vector_cast(a_data);
+			auto size = static_cast<size_type>(data.size());
+
+			if constexpr (dku_trivial_ranges<T> && size == std::extent_v<T>) {
+				DKU_X_ENTER_LAYOUT("trivial range");
+
+				if (a_res.order == ResolveOrder::kSave) {
+					DKU_X_MOCK_WRITE(&data, sizeof(data));
+				} else {
+					DKU_X_MOCK_READ(&data, sizeof(data));
+				}
+
+				DKU_X_LEAVE_LAYOUT();
+			} else {
+				if (a_res.order == ResolveOrder::kSave) {
+					DKU_X_MOCK_WRITE(&size, sizeof(size));
+
+					for (auto elem : data) {
+						resolve(a_res, elem);
+					}
+				} else {
+					DKU_X_MOCK_READ(&size, sizeof(size));
+					data.clear();
+					data.resize(size);
+
+					for (index_type i = 0; i < size; ++i) {
+						data.emplace_back(resolve(a_res, data[i]));
+					};
+				}
+			}
+
+			DKU_X_LEAVE_LAYOUT();
+
+			return model::range_cast<T>(data);
+		}
+
+		// aggregate bindables
+		template <typename T>
+			requires(dku_aggregate<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			DKU_X_ENTER_LAYOUT("aggregate");
+
+			T data = a_data;
+			auto size = static_cast<size_type>(sizeof(data));
+
+			if (a_res.order == ResolveOrder::kSave) {
+				DKU_X_MOCK_WRITE(&size, sizeof(size));
+				resolve(a_res, model::tuple_cast(data));
+			} else {
+				DKU_X_MOCK_READ(&size, sizeof(size));
+
+				if (size != sizeof(data)) {
+					exception::report<T>(exception::code::unexpected_type_mismatch, a_res.header, 
+						fmt::format("expected size: {}B\nread size: {}B", sizeof(data), size));
+				};
+
+				resolve(a_res, model::tuple_cast(data));
+				DKU_X_MOCK_READ(&data, size);
+			}
+
+			DKU_X_LEAVE_LAYOUT();
+
+			return data;
+		}
+
+		// bindables base
+		template <typename T>
+			requires(dku_bindable<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			DKU_X_ENTER_LAYOUT("bindable base");
+
+			T data = a_data;
+			auto size = static_cast<size_type>(sizeof(data));
+
+			if (a_res.order == ResolveOrder::kSave) {
+				DKU_X_MOCK_WRITE(&size, sizeof(size));
+
+				resolve<T, std::tuple_size_v<T>>(a_res, data);
+			} else {
+				DKU_X_MOCK_READ(&size, sizeof(size));
+
+			}
+
+			DKU_X_LEAVE_LAYOUT();
+
+			return data;
+		}
+
+		// bindables iterator
+		template <typename T, std::size_t N>
+			requires(dku_bindable<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			DKU_X_ENTER_LAYOUT("bindable iterator");
+
+			T data = a_data;
+
+			resolve(a_res, std::get<N - 1>(a_data));
+
+			DKU_X_LEAVE_LAYOUT();
+
+			if constexpr (N > 1) {
+				resolve<T, N - 1>(a_res, a_data);
+			}
+
+			return data;
+		}
+
+		// string type
+		template <typename T>
+			requires(dku_string<T>)
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			DKU_X_ENTER_LAYOUT("string");
+
+			std::string data = a_data;
+			auto size = static_cast<size_type>(data.size());
+
+			if (a_res.order == ResolveOrder::kSave) {
+				DKU_X_MOCK_WRITE(&size, sizeof(size));
+				DKU_X_MOCK_WRITE(data.data(), size);
+			} else {
+				DKU_X_MOCK_READ(&size, sizeof(size));
+				data.resize(size);
+				DKU_X_MOCK_READ(data.data(), size);
+			}
+
+			DKU_X_LEAVE_LAYOUT();
+
+			return data;
+		}
+
+		// default
+		template <typename T>
+		auto resolve(const ResolveInfo& a_res, T a_data) noexcept
+		{
+			if (dku_queue<T>) {
+				exception::report<T>(exception::code::unsupported_type_queue, a_res.header,
+					"std::queue<T> is not supported by DKU_X serializer.\n"
+					"consider using a different type.");
+			} else {
+				exception::report<T>(exception::code::bindable_type_unpackable, a_res.header,
+					"type unpacking is using fallback resolver, which is disabled.\n"
+					"consider using a different type that has flatter data representation.");
+			}
+		}
+
+		template <typename T>
+		auto resolve_save(SKSE::SerializationInterface* a_intfc, ISerializable::Header& a_header, T a_data) noexcept
+		{
+			using type = std::remove_cvref_t<T>;
+
+			DEBUG("DKU_X: resolving for saving -> {}\n{}", a_header.name, typeid(type).name());
+
+			detail::ResolvedLayoutMap[a_header.name] = 0;
+
+			resolve<type>({ ResolveOrder::kSave, a_header, a_intfc }, a_data);
+		}
+	}  // namespace resolver
+} // namespace DKUtil::serialization

--- a/include/DKUtil/Impl/Extra/Serialization/shared.hpp
+++ b/include/DKUtil/Impl/Extra/Serialization/shared.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+
+#include "DKUtil/Logger.hpp"
+#include "DKUtil/Utility.hpp"
+
+
+#define DKU_X_SERIALIZE_MAJOR 1
+#define DKU_X_SERIALIZE_MINOR 0
+#define DKU_X_SERIALIZE_REVISION 0
+
+
+namespace DKUtil
+{
+	constexpr auto DKU_XS_VERSION = DKU_X_SERIALIZE_MAJOR * 10000 + DKU_X_SERIALIZE_MINOR * 100 + DKU_X_SERIALIZE_REVISION;
+}  // namespace DKUtil
+
+
+namespace DKUtil::serialization
+{
+	using size_type = std::uint32_t;
+	using index_type = std::uint32_t;
+	using key_type = std::string;
+	using hash_type = std::uint32_t;
+	using version_type = std::uint32_t;
+
+
+	enum class ResolveOrder : std::uint32_t
+	{
+		kSave = 0,
+		kLoad,
+		kRevert,
+		kInternal,
+	};
+
+	struct ISerializable
+	{
+		struct Header
+		{
+			key_type name;
+			hash_type hash;
+			version_type version;
+		};
+
+		virtual void enable() noexcept
+		{
+			disable();
+			ManagedSerializables.emplace_back(this);
+		}
+
+		virtual void disable() noexcept
+		{
+			std::erase_if(ManagedSerializables, [this](auto* a_ptr) { return a_ptr == this; });
+		}
+
+		virtual ~ISerializable() noexcept
+		{
+			disable();
+			TRACE("{}", ManagedSerializables.size());
+		}
+
+		static void SaveAll(SKSE::SerializationInterface* a_intfc) noexcept
+		{
+			for (auto* serializable : ManagedSerializables) {
+				serializable->do_save(a_intfc);
+			}
+		}
+
+		static void LoadAll(SKSE::SerializationInterface* a_intfc) noexcept
+		{
+			for (auto* serializable : ManagedSerializables) {
+				serializable->do_load(a_intfc);
+			}
+		}
+
+		static void RevertAll(SKSE::SerializationInterface* a_intfc) noexcept
+		{
+			for (auto* serializable : ManagedSerializables) {
+				serializable->do_revert(a_intfc);
+			}
+		}
+
+	protected:
+		virtual void do_save(SKSE::SerializationInterface* a_intfc) = 0;
+		virtual void do_load(SKSE::SerializationInterface* a_intfc) = 0;
+		virtual void do_revert(SKSE::SerializationInterface* a_intfc) = 0;
+
+		inline static std::vector<ISerializable*> ManagedSerializables = {};
+	};
+} // namespace DKUtil::Serialization

--- a/include/DKUtil/Impl/Extra/xconsole.hpp
+++ b/include/DKUtil/Impl/Extra/xconsole.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "DKUtil/Logger.hpp"
+#include "DKUtil/Utility.hpp"
+
+
+#define CONSOLE(...)                                                          \
+	{                                                                         \
+		if (auto* console = RE::ConsoleLog::GetSingleton()) {                 \
+			auto fmt = fmt::format(__VA_ARGS__);                              \
+			INFO("[console] {}", fmt);                                        \
+			console->Print(fmt::format("{}->{}", PROJECT_NAME, fmt).c_str()); \
+		}                                                                     \
+	}

--- a/include/DKUtil/Impl/Extra/xserialize.hpp
+++ b/include/DKUtil/Impl/Extra/xserialize.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+
+/*
+* 
+ * 1.0.0
+ * Basic serialization and deserialization;
+ * Support (should) all types that are commonly used;
+ * Flatten user defined types for thorough serialization;
+ * Concept constrained auto templates;
+ * 
+ */
+
+
+#include "DKUtil/Logger.hpp"
+#include "DKUtil/Utility.hpp"
+
+
+#define DKU_X_MOCK
+
+#include "Serialization/shared.hpp"
+#include "Serialization/exception.hpp"
+#include "Serialization/interface.hpp"
+#include "Serialization/resolver.hpp"
+#include "Serialization/variant.hpp"
+#include "Serialization/mock.hpp"
+
+
+namespace DKUtil::serialization
+{
+	namespace colliding
+	{
+		inline static constexpr hash_type KnownHash[] = {
+			'ISCR',
+			'COMP',
+		};
+
+		inline constexpr auto make_hash_key(const char* a_key)
+		{
+			key_type key = dku::string::join({ PROJECT_NAME, a_key }, "_");
+
+			while (std::ranges::contains(KnownHash, dku::numbers::FNV_1A_32(key))) {
+				key += "_";
+			}
+
+			return std::make_pair(key, dku::numbers::FNV_1A_32(key));
+		}
+	}  // namespace colliding
+
+
+	template <typename T, dku::string::static_string HEADER, version_type VERSION = 1>
+	struct Serializable : ISerializable
+	{
+		using type = std::remove_cvref_t<T>;
+		using resolver_func_t = std::add_pointer_t<void(type&, ResolveOrder, SKSE::SerializationInterface*)>;
+
+		constexpr Serializable() noexcept
+		{
+			auto&& [name, hash] = colliding::make_hash_key(HEADER.c);
+
+			_header.name = name;
+			_header.hash = hash;
+			_header.version = VERSION;
+
+			ISerializable::enable();
+			INFO("{} {}", _header.name, ManagedSerializables.size());
+		}
+
+		constexpr Serializable(const type& a_data) noexcept :
+			Serializable()
+		{
+			_data = a_data;
+		}
+
+		constexpr Serializable(type&& a_data) noexcept :
+			Serializable()
+		{
+			_data = std::move(a_data);
+		}
+
+		constexpr Serializable& operator=(const type& a_data) noexcept
+		{
+			_data = a_data;
+			return *this;
+		}
+
+		constexpr Serializable& operator=(type&& a_data) noexcept
+		{
+			_data = std::move(a_data);
+			return *this;
+		}
+
+		~Serializable() noexcept = default;
+
+		constexpr auto* operator->() noexcept { return std::addressof(_data); }
+		constexpr auto& operator*() noexcept { return _data; }
+		constexpr auto get() noexcept { return _data; }
+
+		constexpr void add_resolver(resolver_func_t a_func) noexcept
+		{
+			_resolvers.emplace_back(a_func);
+		}
+
+	protected:
+		void do_save(SKSE::SerializationInterface* a_intfc) override
+		{
+			INFO("saving {}...", _header.name);
+
+			resolver::resolve_save(a_intfc, _header, _data);
+
+			for (auto& resolver : _resolvers) {
+				resolver(_data, ResolveOrder::kSave, a_intfc);
+			}
+
+			INFO("...done saving {}", _header.name);
+			DKU_X_MOCK_REPORT();
+		}
+
+		void do_load(SKSE::SerializationInterface* a_intfc) override
+		{
+			INFO("loading {}...", _header.name);
+
+			for (auto& resolver : _resolvers) {
+				resolver(_data, ResolveOrder::kLoad, a_intfc);
+			}
+
+			INFO("...done loading {}", _header.name);
+		}
+
+		void do_revert(SKSE::SerializationInterface* a_intfc) override
+		{
+			INFO("reverting {}...", _header.name);
+
+
+			for (auto& resolver : _resolvers) {
+				resolver(_data, ResolveOrder::kRevert, a_intfc);
+			}
+
+			_data = type{};
+
+			INFO("...done reverting {}", _header.name);
+		}
+
+	private:
+		/// revert interface
+
+		// clear data
+		void revert([[maybe_unused]] SKSE::SerializationInterface* a_intfc, T a_data) noexcept
+		{
+			INFO(" revert");
+
+			_data = type{};
+		}
+
+
+		type _data;
+		Header _header;
+		std::vector<resolver_func_t> _resolvers;
+	};
+
+
+	inline static void RegisterSerializable() noexcept
+	{
+		const auto* serialization = SKSE::GetSerializationInterface();
+		serialization->SetSaveCallback(ISerializable::SaveAll);
+		serialization->SetLoadCallback(ISerializable::LoadAll);
+		serialization->SetRevertCallback(ISerializable::RevertAll);
+
+		INFO("DKU_X: Registered serializables");
+	}
+} // namespace DKUtil::serialization

--- a/include/DKUtil/Impl/Utility/templates.hpp
+++ b/include/DKUtil/Impl/Utility/templates.hpp
@@ -324,7 +324,7 @@ namespace DKUtil::model
 	inline constexpr auto vector_cast(T&& object) noexcept
 	{
 		using type = concepts::dku_value_type<std::remove_cvref_t<T>>;
-		return std::vector<type>{ std::ranges::begin(object), std::ranges::begin(object) };
+		return object | std::ranges::to<std::vector<type>>();
 	}
 
 	template <typename T, typename F>
@@ -332,8 +332,11 @@ namespace DKUtil::model
 	inline constexpr auto range_cast(F&& object) noexcept
 	{
 		using to_type = std::remove_cvref_t<T>;
-
-		return object | std::ranges::to<to_type>();
+		if constexpr (requires { object | std::ranges::to<to_type>(); }) {
+			return object | std::ranges::to<to_type>();
+		} else {
+			return to_type{ std::begin(object), std::end(object) };
+		}
 	}
 };  // namespace DKUtil::model
 

--- a/include/DKUtil/Impl/Utility/templates.hpp
+++ b/include/DKUtil/Impl/Utility/templates.hpp
@@ -117,21 +117,19 @@ namespace DKUtil::model
 	}
 
 	template <typename T>
-		requires(concepts::dku_trivial_ranges<T>)
 	inline consteval auto number_of_bindables() noexcept
 	{
 		using type = std::remove_cvref_t<T>;
 
-		return std::extent_v<type>;
+		if constexpr (requires { std::extent_v<type>; }) {
+			return std::extent_v<type>;
+		} else {
+			return std::size(type{});
+		}
 	}
 
 	template <typename T>
-	inline consteval auto number_of_bindables() noexcept
-	{
-		using type = std::remove_cvref_t<T>;
-
-		return std::size(type{});
-	}
+	inline constexpr auto number_of_bindables_v = number_of_bindables<T>();
 
 	template <typename First, typename... T>
 	[[nodiscard]] inline bool is_in(First&& first, T&&... t)
@@ -265,14 +263,14 @@ namespace DKUtil::model
 	// clang-format on
 
 #define MAKE_TUPLE_PARAM(n, macro)                    \
-	if constexpr (number_of_bindables<type>() == n) { \
+	if constexpr (number_of_bindables_v<type> == n) { \
 		auto&& [macro(PARGS_MACRO)] = object;         \
 		return std::make_tuple(macro(PARGS_MACRO));   \
 	} else
 
 
 #define MAKE_STRUCT_PARAM(n, macro)                      \
-	if constexpr (number_of_bindables<to_type>() == n) { \
+	if constexpr (number_of_bindables_v<to_type> == n) { \
 		auto&& [macro(TARGS_MACRO)] = to_type{};         \
 		auto&& [macro(PARGS_MACRO)] = object;            \
 		return to_type{ macro(IMPLICIT_PARAM) };         \
@@ -304,7 +302,7 @@ namespace DKUtil::model
 		using to_type = std::remove_cvref_t<T>;
 		using from_type = std::remove_cvref_t<F>;
 
-		static_assert(number_of_bindables<to_type>() == number_of_bindables<from_type>(), 
+		static_assert(number_of_bindables_v<to_type> == number_of_bindables_v<from_type>, 
 			"number of bindables of <F> and <T> must equal.");
 
 		MAKE_STRUCT_PARAM(9, PARAMS_MACRO_9)
@@ -319,6 +317,23 @@ namespace DKUtil::model
 		{
 			return to_type{};
 		}
+	}
+
+	template <typename T>
+		requires(concepts::dku_ranges<T>)
+	inline constexpr auto vector_cast(T&& object) noexcept
+	{
+		using type = concepts::dku_value_type<std::remove_cvref_t<T>>;
+		return std::vector<type>{ std::ranges::begin(object), std::ranges::begin(object) };
+	}
+
+	template <typename T, typename F>
+		requires(concepts::dku_ranges<T> && concepts::dku_ranges<F>)
+	inline constexpr auto range_cast(F&& object) noexcept
+	{
+		using to_type = std::remove_cvref_t<T>;
+
+		return object | std::ranges::to<to_type>();
 	}
 };  // namespace DKUtil::model
 

--- a/include/DKUtil/Logger.hpp
+++ b/include/DKUtil/Logger.hpp
@@ -40,7 +40,13 @@
 
 
 #ifndef DKU_DISABLE_LOGGING
+
+#ifdef DKU_CONSOLE
+#	include <spdlog/sinks/stdout_color_sinks.h>
+#else
 #	include <spdlog/sinks/basic_file_sink.h>
+#endif
+
 #	include <spdlog/spdlog.h>
 
 
@@ -166,7 +172,11 @@ namespace DKUtil::Logger
 		path /= a_name;
 		path += ".log"sv;
 
+#ifdef DKU_CONSOLE
+		auto sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+#else
 		auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(path.string(), true);
+#endif
 
 #ifndef NDEBUG
 		sink->set_pattern("[%i][%l](%s:%#) %v"s);

--- a/test/PluginTest.cpp
+++ b/test/PluginTest.cpp
@@ -2,11 +2,13 @@
 #include "HookTest.h"
 #include "LoggerTest.h"
 #include "UtilityTest.h"
+#include "SSEExtraTest.h"
 
 //#define TEST_CONFIG
 //#define TEST_HOOK
 //#define TEST_LOGGER
-#define TEST_UTILITY
+//#define TEST_UTILITY
+#define TEST_CUSTOM
 //#define TEST_AND_EXIT
 
 namespace
@@ -52,7 +54,7 @@ int main()
 #endif
 
 #ifdef TEST_CUSTOM
-
+	__do_test_run(Extra);
 #endif
 
 #ifdef TEST_AND_EXIT

--- a/test/SSEExtraTest.h
+++ b/test/SSEExtraTest.h
@@ -1,0 +1,43 @@
+#pragma once
+
+
+#include "DKUtil/Extra.hpp"
+
+
+namespace Test::Extra
+{
+	struct ActorDeathInfo
+	{
+		RE::Actor* actor;
+		std::string reason;
+	};
+
+
+	void Run()
+	{
+		dku::serializable<std::map<RE::FormID, ActorDeathInfo>, "MapInfo"> actorDeathInfoMapSerial({
+			{ 0, { nullptr, "testA" } },
+			{ 1, { nullptr, "testB" } },
+			{ 2, { nullptr, "testC" } },
+		});
+		dku::serializable<ActorDeathInfo, "SingleInfo"> actorDeathInfoSerial({ nullptr, "test" });
+
+		dku::serializable<std::set<ActorDeathInfo>, "DeathInfoMap"> actorDeathInfoMap8;
+
+		std::tuple<void*, std::string> testTuple(nullptr, "test");
+
+		dku::serialization::ISerializable::SaveAll(nullptr);
+		//dku::serialization::ISerializable::RevertAll(nullptr);
+		//dku::serialization::ISerializable::LoadAll(nullptr);
+
+		for (auto& [f, s] : *actorDeathInfoMapSerial) {
+			INFO("{} {}", f, s.reason);
+		}
+
+		int a[] = { 1, 2, 3, 4, 5 };
+		auto as = dku::model::vector_cast(a);
+		INFO("{}", as.size());
+
+		constexpr auto ss = dku::model::concepts::dku_aggregate<ActorDeathInfo>;
+	}
+} // namespace Test::Extra

--- a/test/SSEExtraTest.h
+++ b/test/SSEExtraTest.h
@@ -8,35 +8,44 @@ namespace Test::Extra
 {
 	struct ActorDeathInfo
 	{
-		RE::Actor* actor;
+		int actor;
 		std::string reason;
 	};
 
 
 	void Run()
 	{
+		/**/
 		dku::serializable<std::map<RE::FormID, ActorDeathInfo>, "MapInfo"> actorDeathInfoMapSerial({
-			{ 0, { nullptr, "testA" } },
-			{ 1, { nullptr, "testB" } },
-			{ 2, { nullptr, "testC" } },
-		});
-		dku::serializable<ActorDeathInfo, "SingleInfo"> actorDeathInfoSerial({ nullptr, "test" });
+			{ 0, { 11, "testA" } },
+			{ 1, { 22, "testB" } },
+			{ 2, { 33, "testC" } },
+		}); /**/
+		dku::serializable<ActorDeathInfo, "SingleInfo"> actorDeathInfoSerial({ 1234, "test" });
 
-		dku::serializable<std::set<ActorDeathInfo>, "DeathInfoMap"> actorDeathInfoMap8;
+		/**/
+		dku::serializable<std::map<int, int>, "MapInfo"> actorDeathInfoMapSerial({
+			{ 0, 1 },
+			{ 1, 2 },
+			{ 2, 3 },
+		}); /**/
 
 		std::tuple<void*, std::string> testTuple(nullptr, "test");
-
-		dku::serialization::ISerializable::SaveAll(nullptr);
-		//dku::serialization::ISerializable::RevertAll(nullptr);
-		//dku::serialization::ISerializable::LoadAll(nullptr);
+		std::pair<const int, int> as = std::make_tuple(1, 2);
 
 		for (auto& [f, s] : *actorDeathInfoMapSerial) {
 			INFO("{} {}", f, s.reason);
 		}
+		INFO("{}", actorDeathInfoSerial->reason);
 
-		int a[] = { 1, 2, 3, 4, 5 };
-		auto as = dku::model::vector_cast(a);
-		INFO("{}", as.size());
+		dku::serialization::api::detail::save_all(nullptr);
+		dku::serialization::api::detail::revert_all(nullptr);
+		dku::serialization::api::detail::load_all(nullptr);
+
+		for (auto& [f, s] : *actorDeathInfoMapSerial) {
+			INFO("{} {}", f, s.reason);
+		}
+		INFO("{}", actorDeathInfoSerial->reason);
 
 		constexpr auto ss = dku::model::concepts::dku_aggregate<ActorDeathInfo>;
 	}

--- a/test/UtilityTest.h
+++ b/test/UtilityTest.h
@@ -188,7 +188,28 @@ namespace Test::Utility
 
 	void TestModel() noexcept
 	{
-		// enumeration tests
+		struct TestAggregate
+		{
+			int i;
+			std::string s;
+			char c;
+			bool b;
+		};
+
+		auto tv = dku::model::tuple_cast(TestAggregate{});
+		auto sv = dku::model::struct_cast<TestAggregate>(tv);
+		int av[] = { 1, 2, 3, 4 };
+
+		// bindables
+		static_assert(dku::model::number_of_bindables<TestAggregate>() == 4);
+		static_assert(dku::model::number_of_bindables<decltype(tv)>() == 4);
+		static_assert(dku::model::number_of_bindables<decltype(av)>() == 4);
+
+		// concepts
+		static_assert(dku::model::concepts::dku_aggregate<TestAggregate>);
+		static_assert(dku::model::concepts::dku_bindable<decltype(tv)>);
+		static_assert(dku::model::concepts::dku_ranges<decltype(av)>);
+		static_assert(dku::model::concepts::dku_trivial_ranges<decltype(av)>);
 	}
 
 


### PR DESCRIPTION
Any reasonable data type could be wrapped in a `dku::serializable<>` and they will be automatically serialized/deserilized upon game Save/Load/Revert event.