### PR TITLE
Do not elide ERROR or FATAL when DKU_L_DISABLE_INTERNAL_DEBUGGING is set

### DIFF
--- a/include/DKUtil/Logger.hpp
+++ b/include/DKUtil/Logger.hpp
@@ -102,8 +102,6 @@
 #	define __DEBUG(...) void(0)
 #	define __TRACE(...) void(0)
 #	define __WARN(...) void(0)
-#	define ERROR(...) void(0)
-#	define FATAL(...) void(0)
 
 #endif
 


### PR DESCRIPTION
Unlike the `__INFO`, `__DEBUG`, `__TRACE`, and `__WARN` internal logging macros which are both private and purely informative, the `ERROR` and `FATAL` macros are available to be used consumers and have real semantics. The current implementation has the unexpected behavior of release builds preserving debug logs but entirely ignoring errors, which is probably not right. This PR just removes the two lines disabling `ERROR` and `FATAL` when `DKU_L_DISABLE_INTERNAL_DEBUGGING` is set.