### PR TITLE
Separate config options by section

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -30,7 +30,7 @@ Double myDoubleData{ "MyDoubleKey", "General" }; // double
 Boolean myBoolData{ "MyBoolKey" }; // bool
 String myStringData{ "MyStringKey" }; // std::basic_string<char>
 ```
-> Section field is optional and will not stop DKUtil from accessing data, unnamed sections will be put under `Global`.
+> Section field is optional and unnamed sections will be put under `Global`. Section is ignored for JSON.
 
 ## Proxy
 The configuration system in DKUtil works as "proxy per file", each `Proxy` represents one specific configuration file and the subsequent `Load`, `Write`, and `Generate` calls.

--- a/include/DKUtil/Impl/Config/Ini.hpp
+++ b/include/DKUtil/Impl/Config/Ini.hpp
@@ -32,10 +32,10 @@ namespace DKUtil::Config::detail
 						continue;
 					}
 
-					if (_manager.contains(key.pItem)) {
+					if (_manager.contains(std::make_pair(key.pItem, section.pItem))) {
 						std::string raw{ value };
 
-						auto& [data, section] = _manager.at(key.pItem);
+						auto& data = _manager.at(std::make_pair(key.pItem, section.pItem));
 						switch (data->get_type()) {
 						case DataType::kBoolean:
 							{
@@ -143,9 +143,8 @@ namespace DKUtil::Config::detail
 				_ini.Delete(section.pItem, nullptr);
 			}
 
-			for (auto& [key, value] : _manager) {
-				auto*       data = value.first;
-				auto        sanitized = value.second.empty() ? "Global"sv : value.second;
+			for (auto& [key, data] : _manager) {
+				auto        sanitized = key.second.empty() ? "Global"sv : key.second;
 				std::string raw{};
 				switch (data->get_type()) {
 				case DataType::kBoolean:
@@ -179,12 +178,12 @@ namespace DKUtil::Config::detail
 					continue;
 				}
 
-				auto rc = _ini.SetValue(sanitized.data(), key.data(), raw.data());
+				auto rc = _ini.SetValue(sanitized.data(), key.first.data(), raw.data());
 				if (rc == SI_FAIL) {
 					ERROR(
 						"DKU_C: Parser#{}: failed generating default value\n"
-						"File: {}\nKey: {}, Section: {}\Type: {}\nValue: {}",
-						_id, _filepath.data(), key, sanitized, dku::print_enum(data->get_type()), raw.data());
+						"File: {}\nKey: {}, Section: {}\nType: {}\nValue: {}",
+						_id, _filepath.data(), key.first, sanitized, dku::print_enum(data->get_type()), raw.data());
 				}
 			}
 

--- a/include/DKUtil/Impl/Config/Json.hpp
+++ b/include/DKUtil/Impl/Config/Json.hpp
@@ -26,11 +26,10 @@ namespace DKUtil::Config::detail
 				file.close();
 			}
 
-			for (auto& [key, value] : _manager) {
-				auto* data = value.first;
-				auto  raw = _json.find(key.data());
+			for (auto& [key, data] : _manager) {
+				auto raw = _json.find(key.first.data());
 				if (raw == _json.end()) {
-					ERROR("DKU_C: Parser#{}: Retrieving config failed!\nFile: {}\nKey: {}", _id, _filepath.c_str(), key);
+					ERROR("DKU_C: Parser#{}: Retrieving config failed!\nFile: {}\nKey: {}", _id, _filepath.c_str(), key.first);
 				}
 
 				switch (data->get_type()) {
@@ -93,38 +92,37 @@ namespace DKUtil::Config::detail
 		void Generate() noexcept override
 		{
 			_json.clear();
-			for (auto& [key, value] : _manager) {
-				auto* data = value.first;
+			for (auto& [key, data] : _manager) {
 				switch (data->get_type()) {
 				case DataType::kBoolean:
 					{
-						_json[key.data()] = data->As<bool>()->get_data();
+						_json[key.first.data()] = data->As<bool>()->get_data();
 						break;
 					}
 				case DataType::kDouble:
 					{
 						if (auto* raw = data->As<double>(); raw->is_collection()) {
-							_json[key.data()] = raw->get_collection();
+							_json[key.first.data()] = raw->get_collection();
 						} else {
-							_json[key.data()] = raw->get_data();
+							_json[key.first.data()] = raw->get_data();
 						}
 						break;
 					}
 				case DataType::kInteger:
 					{
 						if (auto* raw = data->As<std::int64_t>(); raw->is_collection()) {
-							_json[key.data()] = raw->get_collection();
+							_json[key.first.data()] = raw->get_collection();
 						} else {
-							_json[key.data()] = raw->get_data();
+							_json[key.first.data()] = raw->get_data();
 						}
 						break;
 					}
 				case DataType::kString:
 					{
 						if (auto* raw = data->As<std::basic_string<char>>(); raw->is_collection()) {
-							_json[key.data()] = raw->get_collection();
+							_json[key.first.data()] = raw->get_collection();
 						} else {
-							_json[key.data()] = raw->get_data();
+							_json[key.first.data()] = raw->get_data();
 						}
 						break;
 					}

--- a/include/DKUtil/Impl/Config/Proxy.hpp
+++ b/include/DKUtil/Impl/Config/Proxy.hpp
@@ -123,14 +123,14 @@ namespace DKUtil::Config
 		}
 
 		template <
-			const double min = 1,
-			const double max = 0,
+			const double min = 1.,
+			const double max = 0.,
 			typename data_t>
 		constexpr void Bind(detail::AData<data_t>& a_data, const std::convertible_to<data_t> auto&... a_value) noexcept
 		{
 			static_assert(ConfigFileType != FileType::kSchema, "Schema parser cannot use regular data bindings!");
 
-			_manager.try_emplace(a_data.get_key(), std::make_pair(std::addressof(a_data), a_data.get_section()));
+			_manager.try_emplace(std::make_pair(a_data.get_key(), a_data.get_section()), std::addressof(a_data));
 			a_data.set_range({ min, max });
 			a_data.set_data({ static_cast<data_t>(a_value)... });
 		}

--- a/include/DKUtil/Impl/Config/Shared.hpp
+++ b/include/DKUtil/Impl/Config/Shared.hpp
@@ -71,9 +71,20 @@ namespace DKUtil::Config
 
 	namespace detail
 	{
+		struct section_key_hash
+		{
+			size_t operator()(const std::pair<std::string_view, std::string_view>& key) const
+			{
+				// Hash combining algorithm taken from boost::hash_combine 
+				auto hash = std::hash<std::string_view>()(key.first);
+				hash ^= std::hash<std::string_view>()(key.second) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+				return hash;
+			}
+		};
+
 		class IData;
-		// key, <data*, section?>
-		using manager = std::unordered_map<std::string_view, std::pair<detail::IData*, std::string_view>>;
+		// <key, section?>, data*
+		using manager = std::unordered_map<std::pair<std::string_view, std::string_view>, detail::IData*, section_key_hash>;
 
 		inline static std::uint32_t _Count{ 0 };
 

--- a/include/DKUtil/Impl/Config/Toml.hpp
+++ b/include/DKUtil/Impl/Config/Toml.hpp
@@ -25,9 +25,12 @@ namespace DKUtil::Config::detail
 					__INFO("DKU_C: WARNING\nParser#{}: Sectionless configuration present and skipped.\nPossible inappropriate formatting at [{}]", _id, section.str());
 					continue;
 				} else {
-					for (auto& [key, value] : _manager) {
-						auto* data = value.first;
-						auto  raw = table.as_table()->find(key.data());
+					for (auto& [key, data] : _manager) {
+						if (section != key.second) {
+							continue;
+						}
+
+						auto raw = table.as_table()->find(key.first.data());
 						if (table.as_table()->begin() != table.as_table()->end() &&
 							raw == table.as_table()->end()) {
 							continue;
@@ -166,42 +169,41 @@ namespace DKUtil::Config::detail
 			};
 
 			_toml.clear();
-			for (auto& [key, value] : _manager) {
-				auto*       data = value.first;
-				std::string sanitized = value.second.empty() ? "Global" : value.second.data();
+			for (auto& [key, data] : _manager) {
+				std::string sanitized = key.second.empty() ? "Global" : key.second.data();
 				auto [section, success] = _toml.insert(sanitized, toml::table{});
 				auto* table = section->second.as_table();
 
 				switch (data->get_type()) {
 				case DataType::kBoolean:
 					{
-						table->insert(key, data->As<bool>()->get_data());
+						table->insert(key.first, data->As<bool>()->get_data());
 						break;
 					}
 				case DataType::kDouble:
 					{
 						if (auto* raw = data->As<double>(); raw->is_collection()) {
-							table->insert(key, tableGnt(raw->get_collection()));
+							table->insert(key.first, tableGnt(raw->get_collection()));
 						} else {
-							table->insert(key, raw->get_data());
+							table->insert(key.first, raw->get_data());
 						}
 						break;
 					}
 				case DataType::kInteger:
 					{
 						if (auto* raw = data->As<std::int64_t>(); raw->is_collection()) {
-							table->insert(key, tableGnt(raw->get_collection()));
+							table->insert(key.first, tableGnt(raw->get_collection()));
 						} else {
-							table->insert(key, raw->get_data());
+							table->insert(key.first, raw->get_data());
 						}
 						break;
 					}
 				case DataType::kString:
 					{
 						if (auto* raw = data->As<std::basic_string<char>>(); raw->is_collection()) {
-							table->insert(key, tableGnt(raw->get_collection()));
+							table->insert(key.first, tableGnt(raw->get_collection()));
 						} else {
-							table->insert(key, raw->get_data());
+							table->insert(key.first, raw->get_data());
 						}
 						break;
 					}


### PR DESCRIPTION
Currently config options are only identified by their name, and the section purely serves to organize them in the file. This PR would change that so options are keyed by a pair of their section and their name, allowing the same option name to be reused in multiple sections.