### PR TITLE
Fix: deadlock in BG3 when also using ScriptExtender

### DIFF
--- a/include/DKUtil/Logger.hpp
+++ b/include/DKUtil/Logger.hpp
@@ -159,15 +159,18 @@ namespace DKUtil::Logger
 
 	inline void Init(const std::string_view a_name, const std::string_view a_version) noexcept
 	{
-		auto path = detail::docs_directory();
+		std::filesystem::path path;
 #if defined(SKSEAPI)
+		path = detail::docs_directory();
 		path /= IS_VR ? LOG_PATH_VR : LOG_PATH;
 #elif defined(SFSEAPI)
+		path = detail::docs_directory();
 		path /= LOG_PATH;
 #elif defined(PLUGIN_MODE)
 		path = std::move(std::filesystem::current_path());
 		path /= LOG_PATH;
 #endif
+		path = detail::docs_directory();
 		path /= a_name;
 		path += ".log"sv;
 


### PR DESCRIPTION
Calling docs_directory() or more precisely SHGetKnownFolderPath() can cause a deadlock when launching BG3 while using ScriptExtender.
Since BG3 mods use PLUGIN_MODE anyway, we can avoid calling it there.