### PR TITLE
Add FO4 specific log path

### DIFF
--- a/include/DKUtil/Logger.hpp
+++ b/include/DKUtil/Logger.hpp
@@ -178,7 +178,10 @@ namespace DKUtil::Logger
 	inline void Init(const std::string_view a_name, const std::string_view a_version) noexcept
 	{
 		std::filesystem::path path{};
-#if defined(SKSEAPI)
+#if defined(F4SEAPI)
+		path = detail::docs_directory();
+		path /= LOG_PATH;
+#elif defined(SKSEAPI)
 		path = detail::docs_directory();
 		path /= IS_VR ? LOG_PATH_VR : LOG_PATH;
 #elif defined(SFSEAPI)


### PR DESCRIPTION
When used for Fallout 4 plugins, the logger dumps files in the root directory.
Now it ✨ doesn't ✨.