### PR TITLE
Fix compatibility with VS 17.14 Preview

### DIFF
--- a/include/DKUtil/Impl/Utility/enumeration.hpp
+++ b/include/DKUtil/Impl/Utility/enumeration.hpp
@@ -222,7 +222,7 @@ namespace DKUtil::model
 		template <enum_type E>
 		constexpr const char* cache() const noexcept
 		{
-			static std::regex r("::cache<(.*?)>");
+			std::regex r("::cache<(.*?)>");
 			std::cmatch       m;
 			std::regex_search(__FUNCSIG__, m, r);
 


### PR DESCRIPTION
MSVC broke DKUtil. Removing the "static" flag from that variable seems to allow the code to compile. That parameter within `std::regex_seach` seems to always be a const reference, so it should be make no difference if it's persistent (static) or temporary (locally re-allocated every time).